### PR TITLE
Natural implode

### DIFF
--- a/app/Calendar/TimeEditParser.php
+++ b/app/Calendar/TimeEditParser.php
@@ -71,7 +71,7 @@ class TimeEditParser
     public function studyActivities()
     {
         if (is_array($this->studyActivities)) {
-            return natural_implode($this->studyActivities);
+            return natural_implode_unique($this->studyActivities);
         }
 
         return $this->studyActivities;
@@ -85,7 +85,7 @@ class TimeEditParser
         }
 
         if (is_array($this->activity)) {
-            return natural_implode($this->activity);
+            return natural_implode_unique($this->activity);
         }
 
         return $this->activity;
@@ -94,7 +94,7 @@ class TimeEditParser
     public function lectors()
     {
         if (is_array($this->lectors)) {
-            return natural_implode($this->lectors);
+            return natural_implode_unique($this->lectors);
         }
 
         return $this->lectors;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -18,3 +18,10 @@ if (!function_exists('natural_implode')) {
         return implode(', ', $arr) . ' & ' . $lastItem;
     }
 }
+
+if (!function_exists('natural_implode_unique')) {
+    function natural_implode_unique(array $arr) : string
+    {
+        return natural_implode(array_unique($arr));
+    }
+}

--- a/tests/Unit/NaturalImplodeTest.php
+++ b/tests/Unit/NaturalImplodeTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
-class HelpersTest extends TestCase
+class NaturalImplodeTest extends TestCase
 {
     /**
      * Check if the natural_implode helper function actually concatenates
@@ -66,5 +66,27 @@ class HelpersTest extends TestCase
     public function natualImplodeShouldReturnNothingIfAnEmptyArrayIsSupplied()
     {
         $this->assertEquals('', natural_implode([]));
+    }
+
+    /**
+     * Check if the natural_implode_unique function actually removes dublicates
+     * from an array before concatenating it.
+     *
+     * @test
+     * @return void
+     */
+    public function naturalImplodeUniqueDoesNotHaveDublicates()
+    {
+        $arr = [
+            'foo', 'bar', 'foo', 'bar'
+        ];
+
+        $this->assertEquals('foo & bar', natural_implode_unique($arr));
+
+        $arr = [
+            'foo', 'foo', 'bar', 'bar'
+        ];
+
+        $this->assertEquals('foo & bar', natural_implode_unique($arr));
     }
 }

--- a/tests/Unit/TimeEditParserTest.php
+++ b/tests/Unit/TimeEditParserTest.php
@@ -125,6 +125,30 @@ class TimeEditParserTest extends TestCase
         $rawData =  "BEGIN:VEVENT\n" .
                     "SUMMARY:".
                     "Study Activity\,  : Projektarbejde og kommunikation. 1407003U-1\, ".
+                    "Study Activity\,  : Grundlæggende programmering. BSGRPRO1KU\, ".
+                    "Name: Henriette Moos\n".
+                    "END:VEVENT";
+
+        $event = new Event($rawData);
+
+        $parser = new TimeEditParser($event);
+
+        $expectedActivities = 'Projektarbejde og kommunikation & Grundlæggende programmering';
+
+        $this->assertEquals($parser->studyActivities(), $expectedActivities);
+    }
+
+    /**
+     * A description for this test
+     *
+     * @test
+     * @return void
+     */
+    public function itCanHandleDublicateStudyActivities()
+    {
+        $rawData =  "BEGIN:VEVENT\n" .
+                    "SUMMARY:".
+                    "Study Activity\,  : Projektarbejde og kommunikation. 1407003U-1\, ".
                     "Study Activity\,  : Projektarbejde og kommunikation. 1407003U-2\, ".
                     "Name: Henriette Moos\n".
                     "END:VEVENT";
@@ -133,7 +157,7 @@ class TimeEditParserTest extends TestCase
 
         $parser = new TimeEditParser($event);
 
-        $expectedActivities = 'Projektarbejde og kommunikation & Projektarbejde og kommunikation';
+        $expectedActivities = 'Projektarbejde og kommunikation';
 
         $this->assertEquals($parser->studyActivities(), $expectedActivities);
     }
@@ -159,5 +183,28 @@ class TimeEditParserTest extends TestCase
         $parser = new TimeEditParser($event);
 
         $this->assertEquals($parser->activity(), 'Exercises & Forelæsning');
+    }
+
+    /**
+     * A description for this test
+     *
+     * @test
+     * @return void
+     */
+    public function itCanHandleDublicateActivityTypes()
+    {
+        $rawData =  "BEGIN:VEVENT\n" .
+                    "SUMMARY:".
+                    "Study Activity\,  : Projektarbejde og kommunikation. 1407003U-1\, ".
+                    "Name: Henriette Moos\, ".
+                    "Activity: Exercises\,  ".
+                    "Activity: Exercises\n".
+                    "END:VEVENT";
+
+        $event = new Event($rawData);
+
+        $parser = new TimeEditParser($event);
+
+        $this->assertEquals($parser->activity(), 'Exercises');
     }
 }


### PR DESCRIPTION
This pr abstractes the array concatenation logic used in TimeEditParser into a seperate helper function to improve code reuse and cleaniness.

I Also added another version of the function which also handles duplicate array elements so that we avoid results like "Forelæsning & Forelæsning: Projektarbejde og kommunikation & Projektarbejde og kommunikation"