### PR TITLE
CalendarController now returns 404 when an invalid calendar id is supplied

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_script:
 
 script:
     - ./vendor/bin/phpunit
-    - ./vendor/bin/phpcs app tests --standard=PSR2
+    - ./vendor/bin/phpcs app tests --standard=ruleset.xml

--- a/app/Calendar/EventTransformer.php
+++ b/app/Calendar/EventTransformer.php
@@ -27,7 +27,7 @@ class EventTransformer
         //If the event is Study Assistance we should not display an activity type
         if ($this->info->studyActivities() == "Study Assistance") {
             $activity = "";
-        } elseif ($activity != "") {
+        } else if ($activity != "") {
             //Only add the colon after the activity if there is an activity
             $activity .= ": ";
         }

--- a/app/Calendar/RemoteCalendar.php
+++ b/app/Calendar/RemoteCalendar.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Calendar;
+
+use \GuzzleHttp\Client;
+
+class RemoteCalendar
+{
+    protected $url;
+
+    protected $client;
+
+    public function __construct($url = null, Client $client)
+    {
+        $this->url = $url;
+        $this->client = $client;
+    }
+
+    public function getUrl()
+    {
+        return $url;
+    }
+
+    public function setUrl($url)
+    {
+        $this->url = $url;
+        return $this;
+    }
+
+    public function setClient(Client $client)
+    {
+        $this->client = $client;
+        return $this;
+    }
+
+    public function fetch()
+    {
+        $res = $this->client->request('GET', $this->url);
+
+        //Since TimeEdit sucks we need to look at the content type to decide if we got an valid calendar or not
+        if ($res->getHeaderLine('content-type') == "text/html; charset=UTF-8" || $res->getStatusCode() == 404) {
+            abort(404);
+        }
+
+        return $res->getBody();
+    }
+}

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -11,6 +11,13 @@ use Illuminate\Support\Facades\Log;
 
 class CalendarController extends Controller
 {
+    protected $calendar;
+
+    public function __construct(Calendar $calendar)
+    {
+        $this->calendar = $calendar;
+    }
+
     public function show($calid, Request $request)
     {
         //Try to fetch the calendar with this id from the cache
@@ -18,10 +25,10 @@ class CalendarController extends Controller
 
         /**
          * If don't have a cached version of the calendar or we're in
-         * we fetch the calendar from TimeEdit
+         * development mode we fetch the calendar from TimeEdit
          */
         if (!$calendar || App::environment('local')) {
-            $calendar = new Calendar("https://cloud.timeedit.net/itu/web/public/$calid.ics");
+            $calendar = $this->calendar->create("https://cloud.timeedit.net/itu/web/public/$calid.ics");
             //After we fetch the calendar we put it into the cache for future requests
             Cache::put($calid, $calendar, 5);
         }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^7.1.3",
         "fideloper/proxy": "^4.0",
+        "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "5.6.*",
         "laravel/tinker": "^1.0",
         "predis/predis": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf8e34beb543713befa980b3ccf50a52",
+    "content-hash": "2c7d587eb30ce45a858abdc6e67fab04",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -365,6 +365,187 @@
                 "trusted proxy"
             ],
             "time": "2018-02-07T20:20:57+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2018-04-22T15:46:56+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "jakub-onderka/php-console-color",
@@ -1064,6 +1245,56 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<ruleset name="CustomCfg">
+	<description>
+		PSR-2 TimeEditEdit version
+	</description>
+
+	<rule ref="PSR2">
+        <!-- parameters with default values does not have to be at the end -->
+        <exclude name="PEAR.Functions.ValidDefaultValue"/>
+        <!-- both else if and elseif are valid -->
+        <exclude name="PSR2.ControlStructures.ElseIfDeclaration"/>
+	</rule>
+</ruleset>

--- a/tests/Feature/CalendarControllerTest.php
+++ b/tests/Feature/CalendarControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Exception\RequestException;
+
+class CalendarControllerTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $mock = new MockHandler([
+            new Response(200, ['content-type' => 'text/html; charset=UTF-8']),
+        ]);
+
+        $client = new Client([
+            'handler' => HandlerStack::create($mock)
+        ]);
+
+        $this->app->instance(Client::class, $client);
+    }
+
+    /**
+     * A basic test example.
+     *
+     * @test
+     * @return void
+     */
+    public function fetchingAnInvalidCalendarShouldResultInA404StatusCode()
+    {
+        $this->withExceptionHandling();
+
+        $this->get('/abc123')
+        ->assertStatus(404);
+    }
+}

--- a/tests/Unit/CalendarTest.php
+++ b/tests/Unit/CalendarTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use \App;
 use App\Calendar\Calendar;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -17,7 +18,7 @@ class CalendarTest extends TestCase
      */
     public function aCalendarCanBeCreatedWithoutData()
     {
-        $calendar = new Calendar();
+        $calendar = App::make(Calendar::class);
 
         $this->assertEquals($calendar->title, null);
         $this->assertEquals($calendar->description, null);
@@ -43,7 +44,8 @@ class CalendarTest extends TestCase
                     "PRODID:-//TimeEdit\\\, //TimeEdit//EN\n".
                     "END:VCALENDAR";
 
-        $calendar = new Calendar($rawData);
+        $calendar = App::make(Calendar::class);
+        $calendar->create($rawData);
 
         $this->assertEquals($calendar->title, 'TimeEdit-SWU 1st year-20180901');
         $this->assertEquals($calendar->description, 'Date limit 2018-08-20 - 2023-09-10');
@@ -69,7 +71,8 @@ class CalendarTest extends TestCase
                     "END:VEVENT".
                     "END:VCALENDAR";
 
-        $calendar = new Calendar($rawData);
+        $calendar = App::make(Calendar::class);
+        $calendar->create($rawData);
 
         $this->assertEquals($calendar->title, 'Calendar Name');
         $this->assertEquals($calendar->description, 'A calendar description');


### PR DESCRIPTION
Refactored calendar fetching so that we can detect invalid calendars and thus return a 404.

Also added a custom ruleset for phpcs since the refactor to use Laravels IOC requires it

fixes #23 